### PR TITLE
Fill in the `auth` type to allow configs with auth

### DIFF
--- a/src/axios.rei
+++ b/src/axios.rei
@@ -13,7 +13,7 @@ type paramsSerializer('a);
 
 type adapter('a, 'b);
 
-type auth;
+type auth = {. "username": string, "password": string};
 
 type onProgress('a);
 


### PR DESCRIPTION
Since the auth type is opaque in the interface, I'm not able to use it in a config. This fills the type in for users of the interface.

Thanks for sharing a great project!