### PR TITLE
remove unused drawCircle

### DIFF
--- a/src/axios.re
+++ b/src/axios.re
@@ -29,8 +29,6 @@ external makeConfig :
   config =
   "";
 
-let drawCircle = (~radius as r: int, ~color as c: int) => r * c;
-
 [@bs.obj]
 external makeConfigWithUrl :
   (


### PR DESCRIPTION
It creates a warning when I compile a project using bs-axios:

```
  Warning number 32
  .../node_modules/bs-axios/src/axios.re 32:5-14
  
  30 │   "";
  31 │ 
  32 │ let drawCircle = (~radius as r: int, ~color as c: int) => r * c;
  33 │ 
  34 │ [@bs.obj]
  
  unused value drawCircle.
```