### PR TITLE
Allow Node.js HTTP/HTTPS agent to be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,20 @@ let headersDict =
 let headers = Axios.Headers.fromDict(headersDict);
 Axios.getc("https://example.com", Axios.makeConfig(~headers, ()));
 ```
+
+### Node.js HTTP/HTTPS Agent
+
+Providing custom Node.js [`HTTP Agent`](https://nodejs.org/api/http.html#http_class_http_agent)
+allows for configuring connection persistence and reuse. For secure connections,
+[`HTTPS Agent`](https://nodejs.org/api/https.html#https_class_https_agent) allows security related
+configuration to be provided.
+
+```reason
+let httpsAgent =
+  Axios.Agent.Https.(config(~rejectUnauthorized=false, ()) |> create);
+
+Axios.getc(
+  "https://insecure-example.com",
+  Axios.makeConfig(~httpsAgent, ()),
+);
+```

--- a/examples/request_examples.re
+++ b/examples/request_examples.re
@@ -48,3 +48,12 @@ let headersDict =
   );
 let headers = Axios.Headers.fromDict(headersDict);
 Axios.getc("https://example.com", Axios.makeConfig(~headers, ()));
+
+/* Node.js Agent */
+let httpsAgent =
+  Axios.Agent.Https.(config(~rejectUnauthorized=false, ()) |> create);
+
+Axios.getc(
+  "https://insecure-example.com",
+  Axios.makeConfig(~httpsAgent, ()),
+);

--- a/src/axios.re
+++ b/src/axios.re
@@ -150,6 +150,8 @@ external makeConfig:
     ~maxRedirects: int=?,
     ~socketPath: string=?,
     ~proxy: proxy=?,
+    ~httpAgent: Axios_agent.Http.t=?,
+    ~httpsAgent: Axios_agent.Https.t=?,
     unit
   ) =>
   config =
@@ -186,6 +188,8 @@ external makeConfigWithUrl:
     ~maxRedirects: int=?,
     ~socketPath: string=?,
     ~proxy: proxy=?,
+    ~httpAgent: Axios_agent.Http.t=?,
+    ~httpsAgent: Axios_agent.Https.t=?,
     unit
   ) =>
   configWithUrl =
@@ -454,3 +458,4 @@ external patchDatac:
   "patch";
 
 module Instance = Axios_instance;
+module Agent = Axios_agent;

--- a/src/axios.rei
+++ b/src/axios.rei
@@ -103,6 +103,8 @@ external makeConfig:
     ~maxRedirects: int=?,
     ~socketPath: string=?,
     ~proxy: proxy=?,
+    ~httpAgent: Axios_agent.Http.t=?,
+    ~httpsAgent: Axios_agent.Https.t=?,
     unit
   ) =>
   config =
@@ -139,6 +141,8 @@ external makeConfigWithUrl:
     ~maxRedirects: int=?,
     ~socketPath: string=?,
     ~proxy: proxy=?,
+    ~httpAgent: Axios_agent.Http.t=?,
+    ~httpsAgent: Axios_agent.Https.t=?,
     unit
   ) =>
   configWithUrl =
@@ -407,3 +411,4 @@ external patchDatac:
   "patch";
 
 module Instance = Axios_instance;
+module Agent = Axios_agent;

--- a/src/axios_agent.re
+++ b/src/axios_agent.re
@@ -1,0 +1,75 @@
+// https://nodejs.org/api/http.html#http_class_http_agent
+module Http = {
+  type t;
+
+  [@bs.deriving abstract]
+  type config = {
+    [@bs.optional]
+    keepAlive: bool,
+    [@bs.optional]
+    keepAliveMsecs: int,
+    [@bs.optional]
+    maxSockets: int,
+    [@bs.optional]
+    maxFreeSockets: int,
+    [@bs.optional]
+    timeout: int,
+  };
+
+  [@bs.module "http"] [@bs.new] external create: config => t = "Agent";
+};
+
+// https://nodejs.org/api/https.html#https_class_https_agent
+module Https = {
+  type t;
+
+  [@bs.deriving abstract]
+  type config = {
+    [@bs.optional]
+    ca: string,
+    [@bs.optional]
+    cert: string,
+    [@bs.optional]
+    ciphers: string,
+    [@bs.optional]
+    clientCertEngine: string,
+    [@bs.optional]
+    crl: string,
+    [@bs.optional]
+    dhparam: string,
+    [@bs.optional]
+    ecdhCurve: string,
+    [@bs.optional]
+    honorCipherOrder: bool,
+    [@bs.optional]
+    key: string,
+    [@bs.optional]
+    keepAlive: bool,
+    [@bs.optional]
+    keepAliveMsecs: int,
+    [@bs.optional]
+    maxSockets: int,
+    [@bs.optional]
+    maxFreeSockets: int,
+    [@bs.optional]
+    maxCachedSessions: int,
+    [@bs.optional]
+    passphrase: string,
+    [@bs.optional]
+    pfx: string,
+    [@bs.optional]
+    rejectUnauthorized: bool,
+    [@bs.optional]
+    secureOptions: int,
+    [@bs.optional]
+    secureProtocol: string,
+    [@bs.optional]
+    servername: string,
+    [@bs.optional]
+    sessionIdContext: string,
+    [@bs.optional]
+    timeout: int,
+  };
+
+  [@bs.module "https"] [@bs.new] external create: config => t = "Agent";
+};


### PR DESCRIPTION
Hi there! Thanks a bunch for writing and sharing this binding 👌 

In some edge case scenarios, it's important to be able to configure the underlying Node.js HTTP/HTTPS agent used when perform outgoing requests. Examples are adjusting keep alive sockets, various TLS/SSL options etc.

These changes allows those agents to be created and provided whenever requests are sent.

Here's a trivial example of allowing insecure HTTPS requests:

```reason
let httpsAgent =
  Axios.Agent.Https.(config(~rejectUnauthorized=false, ()) |> create);

Axios.getc(
  "https://insecure-example.com",
  Axios.makeConfig(~httpsAgent, ()),
);
```

Worth mentioning that I decided to create a new file (`axios_agent.re`) for these agent related things, because I noticed the `require('http')` and `require('http')` in top of the generated JavaScript output when put inside the already existing `axios.re` file. As I assume this binding could also be used clientside, those `require` statements didn't seem like the way to go. 

*Don't hesitate to point out even the most basic type of flaws with this implementation as I'm definitely a ReasonML rookie.*