### PR TITLE
Axios dependency change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,85 @@
 {
   "name": "bs-axios",
   "version": "0.0.43",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "bs-axios",
+      "version": "0.0.43",
+      "license": "MIT",
+      "devDependencies": {
+        "axios": ">= 0.21.1 <= 0.22.0",
+        "bs-platform": "^7.1.0",
+        "prettier": "^2.0.4"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.21.1 <= 0.22.0",
+        "bs-platform": "^7.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "node_modules/bs-platform": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.3.1.tgz",
+      "integrity": "sha512-RlQexm6i2gMKsfuHL8IcOHN0R/SQgxiurP96fo2nj71QgQQRh332ahOwIl0p0yNl9DH2Tg7ZV2pjG6MMMkaU6w==",
+      "deprecated": "use 7.3.2 instead",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "bsb": "bsb",
+        "bsc": "bsc",
+        "bsrefmt": "bsrefmt",
+        "bstracing": "lib/bstracing"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
   "dependencies": {
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -21,7 +93,8 @@
     "follow-redirects": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "dev": true
     },
     "prettier": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -23,16 +23,15 @@
     "postversion": "npm publish"
   },
   "peerDependencies": {
+    "axios": ">= 0.21.1 <= 0.22.0",
     "bs-platform": "^7.1.0"
-  },
-  "dependencies": {
-    "axios": "^0.21.1"
   },
   "bugs": {
     "url": "https://github.com/meafmira/bs-axios/issues"
   },
   "homepage": "https://github.com/meafmira/bs-axios#readme",
   "devDependencies": {
+    "axios": ">= 0.21.1 <= 0.22.0",
     "bs-platform": "^7.1.0",
     "prettier": "^2.0.4"
   }


### PR DESCRIPTION
Hi :) Thank you so much for writing and sharing axios bindings 🌟 

Perhaps, could `moving axios to be in peerDependencies and devDependencies` be an option to consider to solve the below case? 😄  
In some cases, having axios as a dependency seems to lead to have duplicated dependencies and may lead to inconsistencies between installed axios. 

```
myproject@1.1.2
├── axios@0.22.0
└─┬ bs-axios@0.0.43
  └── axios@0.21.4
```

The [axios v0.22.0](https://github.com/axios/axios/releases/tag/v0.22.0) seems to be the last version without breaking changes, so the version `>= 0.21.1 <= 0.22.0` was provided for axios.

I am a Reasonml beginner and it's the first time to propose something. Please don't hesitate to let me know if I've missed out anything  🙏 